### PR TITLE
Multiple leave request approval bug

### DIFF
--- a/application/modules/default/controllers/LeaverequestController.php
+++ b/application/modules/default/controllers/LeaverequestController.php
@@ -1066,10 +1066,12 @@ class Default_LeaverequestController extends Zend_Controller_Action
 						$message = '<div>Hi,</div><div>The below leave(s) has been cancelled.</div>';
 					}elseif(sapp_Global::_decrypt($status)=='Approved'){
 						$leavestatus =2;
-						if(!empty($leavetypeArr)) {
-							if($leavetypeArr[0]['leavepredeductable'] == 1) {		
-							  	$updateemployeeleave = $leaverequestmodel->updateemployeeleaves($leave_details['appliedleavescount'],$leave_details['user_id']);
-							  }
+						if($leave_details['leavestatus']!='Approved') {
+							if(!empty($leavetypeArr)) {
+								if($leavetypeArr[0]['leavepredeductable'] == 1) {		
+									$updateemployeeleave = $leaverequestmodel->updateemployeeleaves($leave_details['appliedleavescount'],$leave_details['user_id']);
+								  }
+							}
 						}
 						$successmsg ='Leave request approved succesfully.';
 						$subject = 'Leave request approved';

--- a/application/modules/default/forms/empleaves.php
+++ b/application/modules/default/forms/empleaves.php
@@ -34,14 +34,14 @@ class Default_Form_empleaves extends Zend_Form
 			
 		
 		$emp_leave_limit = new Zend_Form_Element_Text('leave_limit');
-        $emp_leave_limit->setAttrib('maxLength', 3);
+        $emp_leave_limit->setAttrib('maxLength', 4);
         $emp_leave_limit->addFilter(new Zend_Filter_StringTrim());
 		$emp_leave_limit->setRequired(true);
         $emp_leave_limit->addValidator('NotEmpty', false, array('messages' => 'Please enter leave limit for current year.'));
 		
 		$emp_leave_limit->addValidator("regex",true,array(
                 
-						   'pattern'=>'/^(\-?[1-9]|\-?[1-9][0-9])$/',
+						   'pattern'=>'/^((\-?[0-9]|\-?[1-9][0-9])\.?[5]?)$/',
                 
                            'messages'=>array(
                                'regexNotMatch'=>'Leave limit must be in the range of 0 to 100.'


### PR DESCRIPTION
When we approve a single leave request multiple time, the employee used leave is increased as well. Thus, if the request has already been approved, no need to update employee used leave