### PR TITLE
Added reason for Leave for manager approval

### DIFF
--- a/application/modules/default/models/Leaverequest.php
+++ b/application/modules/default/models/Leaverequest.php
@@ -282,7 +282,7 @@ class Default_Model_Leaverequest extends Zend_Db_Table_Abstract
 				}
 				
 				$tableFields = array('action'=>'Action','userfullname' => 'Employee','leavetype' => 'Leave Type',
-                    'from_date' => 'From','to_date' => 'To','appliedleavescount' => 'Days','leavestatus' => 'Leave Status');
+                    'from_date' => 'From','to_date' => 'To','appliedleavescount' => 'Days','leavestatus' => 'Leave Status','reason' => 'Reason for Leave');
 		
 		        $leave_arr = array('' => 'All',1 =>'Full Day',2 => 'Half Day');
 


### PR DESCRIPTION
When logged in as Manager --> Self Service --> Leaves --> Employee Leave 
Here, managers are not able to see the reason of leave. So added the reason.